### PR TITLE
fix: isNonGUI doesn't work for distributed tests

### DIFF
--- a/src/main/java/com/di/jmeter/config/ExtendedCsvDataSetConfig.java
+++ b/src/main/java/com/di/jmeter/config/ExtendedCsvDataSetConfig.java
@@ -200,10 +200,14 @@ public class ExtendedCsvDataSetConfig extends ConfigTestElement implements LoopI
         }
     }
 
+    private boolean isServerMode() {
+        return System.getProperty("server_port") != null;
+    }
+
     @Override
     public void testStarted() {
         FileServerExtended fileServer = FileServerExtended.getFileServer();
-        if(JMeter.isNonGUI()){
+        if(JMeter.isNonGUI() || isServerMode()){
             String baseDirectory = org.apache.jmeter.services.FileServer.getFileServer().getBaseDir();
             fileServer.setBasedir(baseDirectory);
         }else {


### PR DESCRIPTION
Add additional check to cover distributed mode.
isNonGUI() check returns false for Jmeter running in distributed/server mode

see #19 