### PR TITLE
Fixed NPE error when reading CSV file with fewer lines than number of…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.di.jmeter.ecsv</groupId>
     <artifactId>di-extended-csv</artifactId>
-    <version>2.3</version>
+    <version>2.4</version>
 <!--Properties-->
     <properties>
         <jmeter-version>5.6.3</jmeter-version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>2.3</version>
 <!--Properties-->
     <properties>
-        <jmeter-version>5.1.1</jmeter-version>
+        <jmeter-version>5.6.3</jmeter-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jdk.version>1.8</jdk.version>
@@ -31,6 +31,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io-version}</version>
         </dependency>
     </dependencies>
 <!--Build Info-->

--- a/src/main/java/com/di/jmeter/utils/FileServerExtended.java
+++ b/src/main/java/com/di/jmeter/utils/FileServerExtended.java
@@ -722,6 +722,8 @@ public class FileServerExtended {
      */
     public String[] csvReadLine(String line, char delimiter) throws IOException {
         int index = 0;
+        if (line == null || line.isEmpty())
+            return new String[0];
         int length = line.length();
         ParserState state = ParserState.INITIAL;
         List<String> list = new ArrayList<>();


### PR DESCRIPTION
If number of lines in the CSV file is lower than number of threads set in the Thread Group csvReadLine throws NPE.
This PR contains a simple fix, tested.